### PR TITLE
fix goroutine leak when process exits.

### DIFF
--- a/state.go
+++ b/state.go
@@ -155,6 +155,14 @@ func (m *Memberlist) triggerFunc(stagger time.Duration, C <-chan time.Time, stop
 		select {
 		case <-C:
 			f()
+
+			// If f() takes a long time, we need check stop after f() returns
+			// to avoid random picking in select and never returns.
+			select {
+			case <-stop:
+				return
+			default:
+			}
 		case <-stop:
 			return
 		}


### PR DESCRIPTION
The function in triggerFunc may take a long time to run and cause never return because of the random picking in select. So the stop channel needs to be checked after the function returns.