### PR TITLE
Support domain name as members, which is useful in cloud deployment.

### DIFF
--- a/config.go
+++ b/config.go
@@ -246,10 +246,10 @@ type Config struct {
 	// a message to that node.
 	RequireNodeNames bool
 
-	// CIDRsAllowed If nil, allow any connection (default), otherwise specify all networks
-	// allowed to connect (you must specify IPv6/IPv4 separately)
+	// HostsAllowed If nil, allow any connection (default), otherwise specify all networks
+	// allowed to connect.
 	// Using [] will block all connections.
-	CIDRsAllowed []net.IPNet
+	HostsAllowed []string
 
 	// MetricLabels is a map of optional labels to apply to all metrics emitted.
 	MetricLabels []metrics.Label
@@ -325,7 +325,7 @@ func DefaultLANConfig() *Config {
 
 		HandoffQueueDepth: 1024,
 		UDPBufferSize:     1400,
-		CIDRsAllowed:      nil, // same as allow all
+		HostsAllowed:      nil, // same as allow all
 
 		QueueCheckInterval: 30 * time.Second,
 	}
@@ -347,22 +347,22 @@ func DefaultWANConfig() *Config {
 	return conf
 }
 
-// IPMustBeChecked return true if IPAllowed must be called
-func (c *Config) IPMustBeChecked() bool {
-	return len(c.CIDRsAllowed) > 0
+// HostMustBeChecked return true if HostAllowed must be called
+func (c *Config) HostMustBeChecked() bool {
+	return len(c.HostsAllowed) > 0
 }
 
-// IPAllowed return an error if access to memberlist is denied
-func (c *Config) IPAllowed(ip net.IP) error {
-	if !c.IPMustBeChecked() {
+// HostAllowed return an error if access to memberlist is denied
+func (c *Config) HostAllowed(host string) error {
+	if !c.HostMustBeChecked() {
 		return nil
 	}
-	for _, n := range c.CIDRsAllowed {
-		if n.Contains(ip) {
+	for _, n := range c.HostsAllowed {
+		if n == host {
 			return nil
 		}
 	}
-	return fmt.Errorf("%s is not allowed", ip)
+	return fmt.Errorf("%s is not allowed", host)
 }
 
 // DefaultLocalConfig works like DefaultConfig, however it returns a configuration

--- a/config_test.go
+++ b/config_test.go
@@ -1,7 +1,6 @@
 package memberlist
 
 import (
-	"net"
 	"testing"
 )
 
@@ -17,76 +16,14 @@ func Test_IsValidAddressDefaults(t *testing.T) {
 	}
 	config := DefaultLANConfig()
 	for _, ip := range tests {
-		localV4 := net.ParseIP(ip)
-		if err := config.IPAllowed(localV4); err != nil {
+		if err := config.HostAllowed(ip); err != nil {
 			t.Fatalf("IP %s Localhost Should be accepted for LAN", ip)
 		}
 	}
 	config = DefaultWANConfig()
 	for _, ip := range tests {
-		localV4 := net.ParseIP(ip)
-		if err := config.IPAllowed(localV4); err != nil {
+		if err := config.HostAllowed(ip); err != nil {
 			t.Fatalf("IP %s Localhost Should be accepted for WAN", ip)
 		}
 	}
-}
-
-func Test_IsValidAddressOverride(t *testing.T) {
-	t.Parallel()
-	cases := []struct {
-		name    string
-		allow   []string
-		success []string
-		fail    []string
-	}{
-		{
-			name:    "Default, nil allows all",
-			allow:   nil,
-			success: []string{"127.0.0.5", "10.0.0.9", "192.168.1.7", "::1"},
-			fail:    []string{},
-		},
-		{
-			name:    "Only IPv4",
-			allow:   []string{"0.0.0.0/0"},
-			success: []string{"127.0.0.5", "10.0.0.9", "192.168.1.7"},
-			fail:    []string{"fe80::38bc:4dff:fe62:b1ae", "::1"},
-		},
-		{
-			name:    "Only IPv6",
-			allow:   []string{"::0/0"},
-			success: []string{"fe80::38bc:4dff:fe62:b1ae", "::1"},
-			fail:    []string{"127.0.0.5", "10.0.0.9", "192.168.1.7"},
-		},
-		{
-			name:    "Only 127.0.0.0/8 and ::1",
-			allow:   []string{"::1/128", "127.0.0.0/8"},
-			success: []string{"127.0.0.5", "::1"},
-			fail:    []string{"::2", "178.250.0.187", "10.0.0.9", "192.168.1.7", "fe80::38bc:4dff:fe62:b1ae"},
-		},
-	}
-
-	for _, testCase := range cases {
-		t.Run(testCase.name, func(t *testing.T) {
-			config := DefaultLANConfig()
-			var err error
-			config.CIDRsAllowed, err = ParseCIDRs(testCase.allow)
-			if err != nil {
-				t.Fatalf("failed parsing %s", testCase.allow)
-			}
-			for _, ips := range testCase.success {
-				ip := net.ParseIP(ips)
-				if err := config.IPAllowed(ip); err != nil {
-					t.Fatalf("Test case with %s should pass", ip)
-				}
-			}
-			for _, ips := range testCase.fail {
-				ip := net.ParseIP(ips)
-				if err := config.IPAllowed(ip); err == nil {
-					t.Fatalf("Test case with %s should fail", ip)
-				}
-			}
-		})
-
-	}
-
 }

--- a/mock_transport.go
+++ b/mock_transport.go
@@ -70,23 +70,23 @@ type MockTransport struct {
 var _ NodeAwareTransport = (*MockTransport)(nil)
 
 // See Transport.
-func (t *MockTransport) FinalAdvertiseAddr(string, int) (net.IP, int, error) {
+func (t *MockTransport) FinalAdvertiseHost(string, int) (string, int, error) {
 	host, portStr, err := net.SplitHostPort(t.addr.String())
 	if err != nil {
-		return nil, 0, err
+		return "", 0, err
 	}
 
 	ip := net.ParseIP(host)
 	if ip == nil {
-		return nil, 0, fmt.Errorf("Failed to parse IP %q", host)
+		return "", 0, fmt.Errorf("Failed to parse IP %q", host)
 	}
 
 	port, err := strconv.ParseInt(portStr, 10, 16)
 	if err != nil {
-		return nil, 0, err
+		return "", 0, err
 	}
 
-	return ip, int(port), nil
+	return ip.String(), int(port), nil
 }
 
 // See Transport.

--- a/net.go
+++ b/net.go
@@ -96,7 +96,7 @@ type ping struct {
 	// restart with a new name.
 	Node string
 
-	SourceAddr []byte `codec:",omitempty"` // Source address, used for a direct reply
+	SourceHost string `codec:",omitempty"` // Source address, used for a direct reply
 	SourcePort uint16 `codec:",omitempty"` // Source port, used for a direct reply
 	SourceNode string `codec:",omitempty"` // Source name, used for a direct reply
 }
@@ -104,7 +104,7 @@ type ping struct {
 // indirect ping sent to an indirect node
 type indirectPingReq struct {
 	SeqNo  uint32
-	Target []byte
+	Target string
 	Port   uint16
 
 	// Node is sent so the target can verify they are
@@ -114,7 +114,7 @@ type indirectPingReq struct {
 
 	Nack bool // true if we'd like a nack back
 
-	SourceAddr []byte `codec:",omitempty"` // Source address, used for a direct reply
+	SourceHost string `codec:",omitempty"` // Source address, used for a direct reply
 	SourcePort uint16 `codec:",omitempty"` // Source port, used for a direct reply
 	SourceNode string `codec:",omitempty"` // Source name, used for a direct reply
 }
@@ -149,7 +149,7 @@ type suspect struct {
 type alive struct {
 	Incarnation uint32
 	Node        string
-	Addr        []byte
+	Host        string
 	Port        uint16
 	Meta        []byte
 
@@ -183,7 +183,7 @@ type userMsgHeader struct {
 // transferring out node states
 type pushNodeState struct {
 	Name        string
-	Addr        []byte
+	Host        string
 	Port        uint16
 	Meta        []byte
 	Incarnation uint32
@@ -563,8 +563,8 @@ func (m *Memberlist) handlePing(buf []byte, from net.Addr) {
 	}
 
 	addr := ""
-	if len(p.SourceAddr) > 0 && p.SourcePort > 0 {
-		addr = joinHostPort(net.IP(p.SourceAddr).String(), p.SourcePort)
+	if len(p.SourceHost) > 0 && p.SourcePort > 0 {
+		addr = joinHostPort(p.SourceHost, p.SourcePort)
 	} else {
 		addr = from.String()
 	}
@@ -593,12 +593,12 @@ func (m *Memberlist) handleIndirectPing(buf []byte, from net.Addr) {
 
 	// Send a ping to the correct host.
 	localSeqNo := m.nextSeqNo()
-	selfAddr, selfPort := m.getAdvertise()
+	selfHost, selfPort := m.getAdvertise()
 	ping := ping{
 		SeqNo: localSeqNo,
 		Node:  ind.Node,
 		// The outbound message is addressed FROM us.
-		SourceAddr: selfAddr,
+		SourceHost: selfHost,
 		SourcePort: selfPort,
 		SourceNode: m.config.Name,
 	}
@@ -607,8 +607,8 @@ func (m *Memberlist) handleIndirectPing(buf []byte, from net.Addr) {
 	// use that otherwise assume that the other end of the UDP socket is
 	// usable.
 	indAddr := ""
-	if len(ind.SourceAddr) > 0 && ind.SourcePort > 0 {
-		indAddr = joinHostPort(net.IP(ind.SourceAddr).String(), ind.SourcePort)
+	if len(ind.SourceHost) > 0 && ind.SourcePort > 0 {
+		indAddr = joinHostPort(ind.SourceHost, ind.SourcePort)
 	} else {
 		indAddr = from.String()
 	}
@@ -631,7 +631,7 @@ func (m *Memberlist) handleIndirectPing(buf []byte, from net.Addr) {
 	m.setAckHandler(localSeqNo, respHandler, m.config.ProbeTimeout)
 
 	// Send the ping.
-	addr := joinHostPort(net.IP(ind.Target).String(), ind.Port)
+	addr := joinHostPort(ind.Target, ind.Port)
 	a := Address{
 		Addr: addr,
 		Name: ind.Node,
@@ -690,7 +690,7 @@ func (m *Memberlist) handleSuspect(buf []byte, from net.Addr) {
 // ensureCanConnect return the IP from a RemoteAddress
 // return error if this client must not connect
 func (m *Memberlist) ensureCanConnect(from net.Addr) error {
-	if !m.config.IPMustBeChecked() {
+	if !m.config.HostMustBeChecked() {
 		return nil
 	}
 	source := from.String()
@@ -702,11 +702,7 @@ func (m *Memberlist) ensureCanConnect(from net.Addr) error {
 		return err
 	}
 
-	ip := net.ParseIP(host)
-	if ip == nil {
-		return fmt.Errorf("Cannot parse IP from %s", host)
-	}
-	return m.config.IPAllowed(ip)
+	return m.config.HostAllowed(host)
 }
 
 func (m *Memberlist) handleAlive(buf []byte, from net.Addr) {
@@ -719,11 +715,10 @@ func (m *Memberlist) handleAlive(buf []byte, from net.Addr) {
 		m.logger.Printf("[ERR] memberlist: Failed to decode alive message: %s %s", err, LogAddress(from))
 		return
 	}
-	if m.config.IPMustBeChecked() {
-		innerIP := net.IP(live.Addr)
-		if innerIP != nil {
-			if err := m.config.IPAllowed(innerIP); err != nil {
-				m.logger.Printf("[DEBUG] memberlist: Blocked alive.Addr=%s message from: %s %s", innerIP.String(), err, LogAddress(from))
+	if m.config.HostMustBeChecked() {
+		if live.Host != "" {
+			if err := m.config.HostAllowed(live.Host); err != nil {
+				m.logger.Printf("[DEBUG] memberlist: Blocked alive.Addr=%s message from: %s %s", live.Host, err, LogAddress(from))
 				return
 			}
 		}
@@ -995,7 +990,7 @@ func (m *Memberlist) sendLocalState(conn net.Conn, join bool, streamLabel string
 	localNodes := make([]pushNodeState, len(m.nodes))
 	for idx, n := range m.nodes {
 		localNodes[idx].Name = n.Name
-		localNodes[idx].Addr = n.Addr
+		localNodes[idx].Host = n.Host
 		localNodes[idx].Port = n.Port
 		localNodes[idx].Incarnation = n.Incarnation
 		localNodes[idx].State = n.State
@@ -1259,7 +1254,7 @@ func (m *Memberlist) mergeRemoteState(join bool, remoteNodes []pushNodeState, us
 		for idx, n := range remoteNodes {
 			nodes[idx] = &Node{
 				Name:  n.Name,
-				Addr:  n.Addr,
+				Host:  n.Host,
 				Port:  n.Port,
 				Meta:  n.Meta,
 				State: n.State,

--- a/net_test.go
+++ b/net_test.go
@@ -36,7 +36,7 @@ func TestHandleCompoundPing(t *testing.T) {
 	// Encode a ping
 	ping := ping{
 		SeqNo:      42,
-		SourceAddr: udpAddr.IP,
+		SourceHost: udpAddr.IP.String(),
 		SourcePort: uint16(udpAddr.Port),
 		SourceNode: "test",
 	}
@@ -105,7 +105,7 @@ func TestHandlePing(t *testing.T) {
 	// Encode a ping
 	ping := ping{
 		SeqNo:      42,
-		SourceAddr: udpAddr.IP,
+		SourceHost: udpAddr.IP.String(),
 		SourcePort: uint16(udpAddr.Port),
 		SourceNode: "test",
 	}
@@ -170,7 +170,7 @@ func TestHandlePing_WrongNode(t *testing.T) {
 	ping := ping{
 		SeqNo:      42,
 		Node:       m.config.Name + "-bad",
-		SourceAddr: udpAddr.IP,
+		SourceHost: udpAddr.IP.String(),
 		SourcePort: uint16(udpAddr.Port),
 		SourceNode: "test",
 	}
@@ -211,10 +211,10 @@ func TestHandleIndirectPing(t *testing.T) {
 	// Encode an indirect ping
 	ind := indirectPingReq{
 		SeqNo:      100,
-		Target:     net.ParseIP(m.config.BindAddr),
+		Target:     m.config.BindAddr,
 		Port:       uint16(m.config.BindPort),
 		Node:       m.config.Name,
-		SourceAddr: udpAddr.IP,
+		SourceHost: udpAddr.IP.String(),
 		SourcePort: uint16(udpAddr.Port),
 		SourceNode: "test",
 	}
@@ -470,7 +470,7 @@ func TestTCPPushPull(t *testing.T) {
 	m.nodes = append(m.nodes, &nodeState{
 		Node: Node{
 			Name: "Test 0",
-			Addr: net.ParseIP(m.config.BindAddr),
+			Host: m.config.BindAddr,
 			Port: uint16(m.config.BindPort),
 		},
 		Incarnation: 0,
@@ -487,17 +487,17 @@ func TestTCPPushPull(t *testing.T) {
 
 	localNodes := make([]pushNodeState, 3)
 	localNodes[0].Name = "Test 0"
-	localNodes[0].Addr = net.ParseIP(m.config.BindAddr)
+	localNodes[0].Host = m.config.BindAddr
 	localNodes[0].Port = uint16(m.config.BindPort)
 	localNodes[0].Incarnation = 1
 	localNodes[0].State = StateAlive
 	localNodes[1].Name = "Test 1"
-	localNodes[1].Addr = net.ParseIP(m.config.BindAddr)
+	localNodes[1].Host = m.config.BindAddr
 	localNodes[1].Port = uint16(m.config.BindPort)
 	localNodes[1].Incarnation = 1
 	localNodes[1].State = StateAlive
 	localNodes[2].Name = "Test 2"
-	localNodes[2].Addr = net.ParseIP(m.config.BindAddr)
+	localNodes[2].Host = m.config.BindAddr
 	localNodes[2].Port = uint16(m.config.BindPort)
 	localNodes[2].Incarnation = 1
 	localNodes[2].State = StateAlive
@@ -577,7 +577,7 @@ func TestTCPPushPull(t *testing.T) {
 	if n.Name != "Test 0" {
 		t.Fatalf("bad name")
 	}
-	if bytes.Compare(n.Addr, net.ParseIP(m.config.BindAddr)) != 0 {
+	if n.Host != m.config.BindAddr {
 		t.Fatal("bad addr")
 	}
 	if n.Incarnation != 0 {
@@ -596,7 +596,7 @@ func TestSendMsg_Piggyback(t *testing.T) {
 	a := alive{
 		Incarnation: 10,
 		Node:        "rand",
-		Addr:        []byte{127, 0, 0, 255},
+		Host:        "127.0.0.255",
 		Meta:        nil,
 		Vsn: []uint8{
 			ProtocolVersionMin, ProtocolVersionMax, ProtocolVersionMin,
@@ -613,7 +613,7 @@ func TestSendMsg_Piggyback(t *testing.T) {
 	// Encode a ping
 	ping := ping{
 		SeqNo:      42,
-		SourceAddr: udpAddr.IP,
+		SourceHost: udpAddr.IP.String(),
 		SourcePort: uint16(udpAddr.Port),
 		SourceNode: "test",
 	}

--- a/state_test.go
+++ b/state_test.go
@@ -56,7 +56,7 @@ func TestMemberList_Probe(t *testing.T) {
 
 	a1 := alive{
 		Node:        addr1.String(),
-		Addr:        []byte(addr1),
+		Host:        addr1.String(),
 		Port:        uint16(m1.config.BindPort),
 		Incarnation: 1,
 		Vsn:         m1.config.BuildVsnArray(),
@@ -64,7 +64,7 @@ func TestMemberList_Probe(t *testing.T) {
 	m1.aliveNode(&a1, nil, true)
 	a2 := alive{
 		Node:        addr2.String(),
-		Addr:        []byte(addr2),
+		Host:        addr2.String(),
 		Port:        uint16(m2.config.BindPort),
 		Incarnation: 1,
 		Vsn:         m2.config.BuildVsnArray(),
@@ -91,10 +91,6 @@ func TestMemberList_ProbeNode_Suspect(t *testing.T) {
 	addr2 := getBindAddr()
 	addr3 := getBindAddr()
 	addr4 := getBindAddr()
-	ip1 := []byte(addr1)
-	ip2 := []byte(addr2)
-	ip3 := []byte(addr3)
-	ip4 := []byte(addr4)
 
 	m1 := HostMemberlist(addr1.String(), t, func(c *Config) {
 		c.ProbeTimeout = time.Millisecond
@@ -112,13 +108,13 @@ func TestMemberList_ProbeNode_Suspect(t *testing.T) {
 		c.BindPort = bindPort
 	})
 	defer m3.Shutdown()
-	a1 := alive{Node: addr1.String(), Addr: ip1, Port: uint16(bindPort), Incarnation: 1, Vsn: m1.config.BuildVsnArray()}
+	a1 := alive{Node: addr1.String(), Host: addr1.String(), Port: uint16(bindPort), Incarnation: 1, Vsn: m1.config.BuildVsnArray()}
 	m1.aliveNode(&a1, nil, true)
-	a2 := alive{Node: addr2.String(), Addr: ip2, Port: uint16(bindPort), Incarnation: 1, Vsn: m2.config.BuildVsnArray()}
+	a2 := alive{Node: addr2.String(), Host: addr2.String(), Port: uint16(bindPort), Incarnation: 1, Vsn: m2.config.BuildVsnArray()}
 	m1.aliveNode(&a2, nil, false)
-	a3 := alive{Node: addr3.String(), Addr: ip3, Port: uint16(bindPort), Incarnation: 1, Vsn: m3.config.BuildVsnArray()}
+	a3 := alive{Node: addr3.String(), Host: addr3.String(), Port: uint16(bindPort), Incarnation: 1, Vsn: m3.config.BuildVsnArray()}
 	m1.aliveNode(&a3, nil, false)
-	a4 := alive{Node: addr4.String(), Addr: ip4, Port: uint16(bindPort), Incarnation: 1, Vsn: m1.config.BuildVsnArray()}
+	a4 := alive{Node: addr4.String(), Host: addr4.String(), Port: uint16(bindPort), Incarnation: 1, Vsn: m1.config.BuildVsnArray()}
 	m1.aliveNode(&a4, nil, false)
 
 	n := m1.nodeMap[addr4.String()]
@@ -169,7 +165,7 @@ func TestMemberList_ProbeNode_Suspect_Dogpile(t *testing.T) {
 
 			bindPort := m.config.BindPort
 
-			a := alive{Node: addr.String(), Addr: []byte(addr), Port: uint16(bindPort), Incarnation: 1, Vsn: m.config.BuildVsnArray()}
+			a := alive{Node: addr.String(), Host: addr.String(), Port: uint16(bindPort), Incarnation: 1, Vsn: m.config.BuildVsnArray()}
 			m.aliveNode(&a, nil, true)
 
 			// Make all but one peer be an real, alive instance.
@@ -184,14 +180,14 @@ func TestMemberList_ProbeNode_Suspect_Dogpile(t *testing.T) {
 
 				peers = append(peers, peer)
 
-				a = alive{Node: peerAddr.String(), Addr: []byte(peerAddr), Port: uint16(bindPort), Incarnation: 1, Vsn: m.config.BuildVsnArray()}
+				a = alive{Node: peerAddr.String(), Host: peerAddr.String(), Port: uint16(bindPort), Incarnation: 1, Vsn: m.config.BuildVsnArray()}
 				m.aliveNode(&a, nil, false)
 			}
 
 			// Just use a bogus address for the last peer so it doesn't respond
 			// to pings, but tell the memberlist it's alive.
 			badPeerAddr := getBindAddr()
-			a = alive{Node: badPeerAddr.String(), Addr: []byte(badPeerAddr), Port: uint16(bindPort), Incarnation: 1, Vsn: m.config.BuildVsnArray()}
+			a = alive{Node: badPeerAddr.String(), Host: badPeerAddr.String(), Port: uint16(bindPort), Incarnation: 1, Vsn: m.config.BuildVsnArray()}
 			m.aliveNode(&a, nil, false)
 
 			// Force a probe, which should start us into the suspect state.
@@ -554,10 +550,6 @@ func TestMemberList_ProbeNode_Awareness_Degraded(t *testing.T) {
 	addr2 := getBindAddr()
 	addr3 := getBindAddr()
 	addr4 := getBindAddr()
-	ip1 := []byte(addr1)
-	ip2 := []byte(addr2)
-	ip3 := []byte(addr3)
-	ip4 := []byte(addr4)
 
 	var probeTimeMin time.Duration
 	m1 := HostMemberlist(addr1.String(), t, func(c *Config) {
@@ -583,11 +575,11 @@ func TestMemberList_ProbeNode_Awareness_Degraded(t *testing.T) {
 	})
 	defer m3.Shutdown()
 
-	a1 := alive{Node: addr1.String(), Addr: ip1, Port: uint16(bindPort), Incarnation: 1, Vsn: m1.config.BuildVsnArray()}
+	a1 := alive{Node: addr1.String(), Host: addr1.String(), Port: uint16(bindPort), Incarnation: 1, Vsn: m1.config.BuildVsnArray()}
 	m1.aliveNode(&a1, nil, true)
-	a2 := alive{Node: addr2.String(), Addr: ip2, Port: uint16(bindPort), Incarnation: 1, Vsn: m2.config.BuildVsnArray()}
+	a2 := alive{Node: addr2.String(), Host: addr2.String(), Port: uint16(bindPort), Incarnation: 1, Vsn: m2.config.BuildVsnArray()}
 	m1.aliveNode(&a2, nil, false)
-	a3 := alive{Node: addr3.String(), Addr: ip3, Port: uint16(bindPort), Incarnation: 1, Vsn: m3.config.BuildVsnArray()}
+	a3 := alive{Node: addr3.String(), Host: addr3.String(), Port: uint16(bindPort), Incarnation: 1, Vsn: m3.config.BuildVsnArray()}
 	m1.aliveNode(&a3, nil, false)
 
 	vsn4 := []uint8{
@@ -595,7 +587,7 @@ func TestMemberList_ProbeNode_Awareness_Degraded(t *testing.T) {
 		1, 1, 1,
 	}
 	// Node 4 never gets started.
-	a4 := alive{Node: addr4.String(), Addr: ip4, Port: uint16(bindPort), Incarnation: 1, Vsn: vsn4}
+	a4 := alive{Node: addr4.String(), Host: addr4.String(), Port: uint16(bindPort), Incarnation: 1, Vsn: vsn4}
 	m1.aliveNode(&a4, nil, false)
 
 	// Start the health in a degraded state.
@@ -638,10 +630,6 @@ func TestMemberList_ProbeNode_Wrong_VSN(t *testing.T) {
 	addr2 := getBindAddr()
 	addr3 := getBindAddr()
 	addr4 := getBindAddr()
-	ip1 := []byte(addr1)
-	ip2 := []byte(addr2)
-	ip3 := []byte(addr3)
-	ip4 := []byte(addr4)
 
 	m1 := HostMemberlist(addr1.String(), t, func(c *Config) {
 		c.ProbeTimeout = 10 * time.Millisecond
@@ -665,11 +653,11 @@ func TestMemberList_ProbeNode_Wrong_VSN(t *testing.T) {
 	})
 	defer m3.Shutdown()
 
-	a1 := alive{Node: addr1.String(), Addr: ip1, Port: uint16(bindPort), Incarnation: 1, Vsn: m1.config.BuildVsnArray()}
+	a1 := alive{Node: addr1.String(), Host: addr1.String(), Port: uint16(bindPort), Incarnation: 1, Vsn: m1.config.BuildVsnArray()}
 	m1.aliveNode(&a1, nil, true)
-	a2 := alive{Node: addr2.String(), Addr: ip2, Port: uint16(bindPort), Incarnation: 1, Vsn: m2.config.BuildVsnArray()}
+	a2 := alive{Node: addr2.String(), Host: addr2.String(), Port: uint16(bindPort), Incarnation: 1, Vsn: m2.config.BuildVsnArray()}
 	m1.aliveNode(&a2, nil, false)
-	a3 := alive{Node: addr3.String(), Addr: ip3, Port: uint16(bindPort), Incarnation: 1, Vsn: m3.config.BuildVsnArray()}
+	a3 := alive{Node: addr3.String(), Host: addr3.String(), Port: uint16(bindPort), Incarnation: 1, Vsn: m3.config.BuildVsnArray()}
 	m1.aliveNode(&a3, nil, false)
 
 	vsn4 := []uint8{
@@ -677,7 +665,7 @@ func TestMemberList_ProbeNode_Wrong_VSN(t *testing.T) {
 		0, 0, 0,
 	}
 	// Node 4 never gets started.
-	a4 := alive{Node: addr4.String(), Addr: ip4, Port: uint16(bindPort), Incarnation: 1, Vsn: vsn4}
+	a4 := alive{Node: addr4.String(), Host: addr4.String(), Port: uint16(bindPort), Incarnation: 1, Vsn: vsn4}
 	m1.aliveNode(&a4, nil, false)
 
 	// Start the health in a degraded state.
@@ -696,8 +684,6 @@ func TestMemberList_ProbeNode_Wrong_VSN(t *testing.T) {
 func TestMemberList_ProbeNode_Awareness_Improved(t *testing.T) {
 	addr1 := getBindAddr()
 	addr2 := getBindAddr()
-	ip1 := []byte(addr1)
-	ip2 := []byte(addr2)
 
 	m1 := HostMemberlist(addr1.String(), t, func(c *Config) {
 		c.ProbeTimeout = 10 * time.Millisecond
@@ -712,9 +698,9 @@ func TestMemberList_ProbeNode_Awareness_Improved(t *testing.T) {
 	})
 	defer m2.Shutdown()
 
-	a1 := alive{Node: addr1.String(), Addr: ip1, Port: uint16(bindPort), Incarnation: 1, Vsn: m1.config.BuildVsnArray()}
+	a1 := alive{Node: addr1.String(), Host: addr1.String(), Port: uint16(bindPort), Incarnation: 1, Vsn: m1.config.BuildVsnArray()}
 	m1.aliveNode(&a1, nil, true)
-	a2 := alive{Node: addr2.String(), Addr: ip2, Port: uint16(bindPort), Incarnation: 1, Vsn: m2.config.BuildVsnArray()}
+	a2 := alive{Node: addr2.String(), Host: addr2.String(), Port: uint16(bindPort), Incarnation: 1, Vsn: m2.config.BuildVsnArray()}
 	m1.aliveNode(&a2, nil, false)
 
 	// Start the health in a degraded state.
@@ -743,10 +729,6 @@ func TestMemberList_ProbeNode_Awareness_MissedNack(t *testing.T) {
 	addr2 := getBindAddr()
 	addr3 := getBindAddr()
 	addr4 := getBindAddr()
-	ip1 := []byte(addr1)
-	ip2 := []byte(addr2)
-	ip3 := []byte(addr3)
-	ip4 := []byte(addr4)
 
 	var probeTimeMax time.Duration
 	m1 := HostMemberlist(addr1.String(), t, func(c *Config) {
@@ -765,16 +747,16 @@ func TestMemberList_ProbeNode_Awareness_MissedNack(t *testing.T) {
 	})
 	defer m2.Shutdown()
 
-	a1 := alive{Node: addr1.String(), Addr: ip1, Port: uint16(bindPort), Incarnation: 1, Vsn: m1.config.BuildVsnArray()}
+	a1 := alive{Node: addr1.String(), Host: addr1.String(), Port: uint16(bindPort), Incarnation: 1, Vsn: m1.config.BuildVsnArray()}
 	m1.aliveNode(&a1, nil, true)
-	a2 := alive{Node: addr2.String(), Addr: ip2, Port: uint16(bindPort), Incarnation: 1, Vsn: m1.config.BuildVsnArray()}
+	a2 := alive{Node: addr2.String(), Host: addr2.String(), Port: uint16(bindPort), Incarnation: 1, Vsn: m1.config.BuildVsnArray()}
 	m1.aliveNode(&a2, nil, false)
 
 	vsn := m1.config.BuildVsnArray()
 	// Node 3 and node 4 never get started.
-	a3 := alive{Node: addr3.String(), Addr: ip3, Port: uint16(bindPort), Incarnation: 1, Vsn: vsn}
+	a3 := alive{Node: addr3.String(), Host: addr3.String(), Port: uint16(bindPort), Incarnation: 1, Vsn: vsn}
 	m1.aliveNode(&a3, nil, false)
-	a4 := alive{Node: addr4.String(), Addr: ip4, Port: uint16(bindPort), Incarnation: 1, Vsn: vsn}
+	a4 := alive{Node: addr4.String(), Host: addr4.String(), Port: uint16(bindPort), Incarnation: 1, Vsn: vsn}
 	m1.aliveNode(&a4, nil, false)
 
 	// Make sure health looks good.
@@ -818,10 +800,6 @@ func TestMemberList_ProbeNode_Awareness_OldProtocol(t *testing.T) {
 	addr2 := getBindAddr()
 	addr3 := getBindAddr()
 	addr4 := getBindAddr()
-	ip1 := []byte(addr1)
-	ip2 := []byte(addr2)
-	ip3 := []byte(addr3)
-	ip4 := []byte(addr4)
 
 	var probeTimeMax time.Duration
 	m1 := HostMemberlist(addr1.String(), t, func(c *Config) {
@@ -843,15 +821,15 @@ func TestMemberList_ProbeNode_Awareness_OldProtocol(t *testing.T) {
 	})
 	defer m3.Shutdown()
 
-	a1 := alive{Node: addr1.String(), Addr: ip1, Port: uint16(bindPort), Incarnation: 1}
+	a1 := alive{Node: addr1.String(), Host: addr1.String(), Port: uint16(bindPort), Incarnation: 1}
 	m1.aliveNode(&a1, nil, true)
-	a2 := alive{Node: addr2.String(), Addr: ip2, Port: uint16(bindPort), Incarnation: 1}
+	a2 := alive{Node: addr2.String(), Host: addr2.String(), Port: uint16(bindPort), Incarnation: 1}
 	m1.aliveNode(&a2, nil, false)
-	a3 := alive{Node: addr3.String(), Addr: ip3, Port: uint16(bindPort), Incarnation: 1}
+	a3 := alive{Node: addr3.String(), Host: addr3.String(), Port: uint16(bindPort), Incarnation: 1}
 	m1.aliveNode(&a3, nil, false)
 
 	// Node 4 never gets started.
-	a4 := alive{Node: addr4.String(), Addr: ip4, Port: uint16(bindPort), Incarnation: 1}
+	a4 := alive{Node: addr4.String(), Host: addr4.String(), Port: uint16(bindPort), Incarnation: 1}
 	m1.aliveNode(&a4, nil, false)
 
 	// Make sure health looks good.
@@ -891,8 +869,6 @@ func TestMemberList_ProbeNode_Awareness_OldProtocol(t *testing.T) {
 func TestMemberList_ProbeNode_Buddy(t *testing.T) {
 	addr1 := getBindAddr()
 	addr2 := getBindAddr()
-	ip1 := []byte(addr1)
-	ip2 := []byte(addr2)
 
 	m1 := HostMemberlist(addr1.String(), t, func(c *Config) {
 		c.ProbeTimeout = time.Millisecond
@@ -907,8 +883,8 @@ func TestMemberList_ProbeNode_Buddy(t *testing.T) {
 	})
 	defer m2.Shutdown()
 
-	a1 := alive{Node: addr1.String(), Addr: ip1, Port: uint16(bindPort), Incarnation: 1, Vsn: m1.config.BuildVsnArray()}
-	a2 := alive{Node: addr2.String(), Addr: ip2, Port: uint16(bindPort), Incarnation: 1, Vsn: m2.config.BuildVsnArray()}
+	a1 := alive{Node: addr1.String(), Host: addr1.String(), Port: uint16(bindPort), Incarnation: 1, Vsn: m1.config.BuildVsnArray()}
+	a2 := alive{Node: addr2.String(), Host: addr2.String(), Port: uint16(bindPort), Incarnation: 1, Vsn: m2.config.BuildVsnArray()}
 
 	m1.aliveNode(&a1, nil, true)
 	m1.aliveNode(&a2, nil, false)
@@ -939,8 +915,6 @@ func TestMemberList_ProbeNode_Buddy(t *testing.T) {
 func TestMemberList_ProbeNode(t *testing.T) {
 	addr1 := getBindAddr()
 	addr2 := getBindAddr()
-	ip1 := []byte(addr1)
-	ip2 := []byte(addr2)
 
 	m1 := HostMemberlist(addr1.String(), t, func(c *Config) {
 		c.ProbeTimeout = time.Millisecond
@@ -955,9 +929,9 @@ func TestMemberList_ProbeNode(t *testing.T) {
 	})
 	defer m2.Shutdown()
 
-	a1 := alive{Node: addr1.String(), Addr: ip1, Port: uint16(bindPort), Incarnation: 1}
+	a1 := alive{Node: addr1.String(), Host: addr1.String(), Port: uint16(bindPort), Incarnation: 1}
 	m1.aliveNode(&a1, nil, true)
-	a2 := alive{Node: addr2.String(), Addr: ip2, Port: uint16(bindPort), Incarnation: 1}
+	a2 := alive{Node: addr2.String(), Host: addr2.String(), Port: uint16(bindPort), Incarnation: 1}
 	m1.aliveNode(&a2, nil, false)
 
 	n := m1.nodeMap[addr2.String()]
@@ -977,8 +951,6 @@ func TestMemberList_ProbeNode(t *testing.T) {
 func TestMemberList_Ping(t *testing.T) {
 	addr1 := getBindAddr()
 	addr2 := getBindAddr()
-	ip1 := []byte(addr1)
-	ip2 := []byte(addr2)
 
 	m1 := HostMemberlist(addr1.String(), t, func(c *Config) {
 		c.ProbeTimeout = 1 * time.Second
@@ -993,9 +965,9 @@ func TestMemberList_Ping(t *testing.T) {
 	})
 	defer m2.Shutdown()
 
-	a1 := alive{Node: addr1.String(), Addr: ip1, Port: uint16(bindPort), Incarnation: 1}
+	a1 := alive{Node: addr1.String(), Host: addr1.String(), Port: uint16(bindPort), Incarnation: 1}
 	m1.aliveNode(&a1, nil, true)
-	a2 := alive{Node: addr2.String(), Addr: ip2, Port: uint16(bindPort), Incarnation: 1}
+	a2 := alive{Node: addr2.String(), Host: addr2.String(), Port: uint16(bindPort), Incarnation: 1}
 	m1.aliveNode(&a2, nil, false)
 
 	// Do a legit ping.
@@ -1025,11 +997,11 @@ func TestMemberList_ResetNodes(t *testing.T) {
 	})
 	defer m.Shutdown()
 
-	a1 := alive{Node: "test1", Addr: []byte{127, 0, 0, 1}, Incarnation: 1, Vsn: m.config.BuildVsnArray()}
+	a1 := alive{Node: "test1", Host: "127.0.0.1", Incarnation: 1, Vsn: m.config.BuildVsnArray()}
 	m.aliveNode(&a1, nil, false)
-	a2 := alive{Node: "test2", Addr: []byte{127, 0, 0, 2}, Incarnation: 1, Vsn: m.config.BuildVsnArray()}
+	a2 := alive{Node: "test2", Host: "127.0.0.2", Incarnation: 1, Vsn: m.config.BuildVsnArray()}
 	m.aliveNode(&a2, nil, false)
-	a3 := alive{Node: "test3", Addr: []byte{127, 0, 0, 3}, Incarnation: 1, Vsn: m.config.BuildVsnArray()}
+	a3 := alive{Node: "test3", Host: "127.0.0.3", Incarnation: 1, Vsn: m.config.BuildVsnArray()}
 	m.aliveNode(&a3, nil, false)
 	d := dead{Node: "test2", Incarnation: 1}
 	m.deadNode(&d)
@@ -1210,7 +1182,7 @@ func TestMemberList_AliveNode_NewNode(t *testing.T) {
 	})
 	defer m.Shutdown()
 
-	a := alive{Node: "test", Addr: []byte{127, 0, 0, 1}, Incarnation: 1, Vsn: m.config.BuildVsnArray()}
+	a := alive{Node: "test", Host: "127.0.0.1", Incarnation: 1, Vsn: m.config.BuildVsnArray()}
 	m.aliveNode(&a, nil, false)
 
 	if len(m.nodes) != 1 {
@@ -1258,7 +1230,7 @@ func TestMemberList_AliveNode_SuspectNode(t *testing.T) {
 	})
 	defer m.Shutdown()
 
-	a := alive{Node: "test", Addr: []byte{127, 0, 0, 1}, Incarnation: 1, Vsn: m.config.BuildVsnArray()}
+	a := alive{Node: "test", Host: "127.0.0.1", Incarnation: 1, Vsn: m.config.BuildVsnArray()}
 	m.aliveNode(&a, nil, false)
 
 	// Listen only after first join
@@ -1309,7 +1281,7 @@ func TestMemberList_AliveNode_Idempotent(t *testing.T) {
 	})
 	defer m.Shutdown()
 
-	a := alive{Node: "test", Addr: []byte{127, 0, 0, 1}, Incarnation: 1, Vsn: m.config.BuildVsnArray()}
+	a := alive{Node: "test", Host: "127.0.0.1", Incarnation: 1, Vsn: m.config.BuildVsnArray()}
 	m.aliveNode(&a, nil, false)
 
 	// Listen only after first join
@@ -1400,7 +1372,7 @@ func TestMemberList_AliveNode_ChangeMeta(t *testing.T) {
 
 	a := alive{
 		Node:        "test",
-		Addr:        []byte{127, 0, 0, 1},
+		Host:        "127.0.0.1",
 		Meta:        []byte("val1"),
 		Incarnation: 1,
 		Vsn:         m.config.BuildVsnArray()}
@@ -1444,7 +1416,7 @@ func TestMemberList_AliveNode_Refute(t *testing.T) {
 	m := GetMemberlist(t, nil)
 	defer m.Shutdown()
 
-	a := alive{Node: m.config.Name, Addr: []byte{127, 0, 0, 1}, Incarnation: 1, Vsn: m.config.BuildVsnArray()}
+	a := alive{Node: m.config.Name, Host: "127.0.0.1", Incarnation: 1, Vsn: m.config.BuildVsnArray()}
 	m.aliveNode(&a, nil, true)
 
 	// Clear queue
@@ -1453,7 +1425,7 @@ func TestMemberList_AliveNode_Refute(t *testing.T) {
 	// Conflicting alive
 	s := alive{
 		Node:        m.config.Name,
-		Addr:        []byte{127, 0, 0, 1},
+		Host:        "127.0.0.1",
 		Incarnation: 2,
 		Meta:        []byte("foo"),
 		Vsn:         m.config.BuildVsnArray(),
@@ -1487,7 +1459,7 @@ func TestMemberList_AliveNode_Conflict(t *testing.T) {
 	defer m.Shutdown()
 
 	nodeName := "test"
-	a := alive{Node: nodeName, Addr: []byte{127, 0, 0, 1}, Port: 8000, Incarnation: 1, Vsn: m.config.BuildVsnArray()}
+	a := alive{Node: nodeName, Host: "127.0.0.1", Port: 8000, Incarnation: 1, Vsn: m.config.BuildVsnArray()}
 	m.aliveNode(&a, nil, true)
 
 	// Clear queue
@@ -1496,7 +1468,7 @@ func TestMemberList_AliveNode_Conflict(t *testing.T) {
 	// Conflicting alive
 	s := alive{
 		Node:        nodeName,
-		Addr:        []byte{127, 0, 0, 2},
+		Host:        "127.0.0.2",
 		Port:        9000,
 		Incarnation: 2,
 		Meta:        []byte("foo"),
@@ -1511,7 +1483,7 @@ func TestMemberList_AliveNode_Conflict(t *testing.T) {
 	if state.Meta != nil {
 		t.Fatalf("meta should still be nil")
 	}
-	if bytes.Equal(state.Addr, []byte{127, 0, 0, 2}) {
+	if state.Host == "127.0.0.2" {
 		t.Fatalf("address should not be updated")
 	}
 	if state.Port == 9000 {
@@ -1538,7 +1510,7 @@ func TestMemberList_AliveNode_Conflict(t *testing.T) {
 	// New alive node
 	s2 := alive{
 		Node:        nodeName,
-		Addr:        []byte{127, 0, 0, 2},
+		Host:        "127.0.0.2",
 		Port:        9000,
 		Incarnation: 3,
 		Meta:        []byte("foo"),
@@ -1553,7 +1525,7 @@ func TestMemberList_AliveNode_Conflict(t *testing.T) {
 	if !bytes.Equal(state.Meta, []byte("foo")) {
 		t.Fatalf("meta should be updated")
 	}
-	if !bytes.Equal(state.Addr, []byte{127, 0, 0, 2}) {
+	if state.Host != "127.0.0.2" {
 		t.Fatalf("address should be updated")
 	}
 	if state.Port != 9000 {
@@ -1579,7 +1551,7 @@ func TestMemberList_SuspectNode(t *testing.T) {
 	})
 	defer m.Shutdown()
 
-	a := alive{Node: "test", Addr: []byte{127, 0, 0, 1}, Incarnation: 1, Vsn: m.config.BuildVsnArray()}
+	a := alive{Node: "test", Host: "127.0.0.1", Incarnation: 1, Vsn: m.config.BuildVsnArray()}
 	m.aliveNode(&a, nil, false)
 
 	m.changeNode("test", func(state *nodeState) {
@@ -1638,7 +1610,7 @@ func TestMemberList_SuspectNode_DoubleSuspect(t *testing.T) {
 	m := GetMemberlist(t, nil)
 	defer m.Shutdown()
 
-	a := alive{Node: "test", Addr: []byte{127, 0, 0, 1}, Incarnation: 1, Vsn: m.config.BuildVsnArray()}
+	a := alive{Node: "test", Host: "127.0.0.1", Incarnation: 1, Vsn: m.config.BuildVsnArray()}
 	m.aliveNode(&a, nil, false)
 
 	state := m.nodeMap["test"]
@@ -1677,7 +1649,7 @@ func TestMemberList_SuspectNode_OldSuspect(t *testing.T) {
 	m := GetMemberlist(t, nil)
 	defer m.Shutdown()
 
-	a := alive{Node: "test", Addr: []byte{127, 0, 0, 1}, Incarnation: 10, Vsn: m.config.BuildVsnArray()}
+	a := alive{Node: "test", Host: "127.0.0.1", Incarnation: 10, Vsn: m.config.BuildVsnArray()}
 	m.aliveNode(&a, nil, false)
 
 	state := m.nodeMap["test"]
@@ -1703,7 +1675,7 @@ func TestMemberList_SuspectNode_Refute(t *testing.T) {
 	m := GetMemberlist(t, nil)
 	defer m.Shutdown()
 
-	a := alive{Node: m.config.Name, Addr: []byte{127, 0, 0, 1}, Incarnation: 1, Vsn: m.config.BuildVsnArray()}
+	a := alive{Node: m.config.Name, Host: "127.0.0.1", Incarnation: 1, Vsn: m.config.BuildVsnArray()}
 	m.aliveNode(&a, nil, true)
 
 	// Clear queue
@@ -1760,7 +1732,7 @@ func TestMemberList_DeadNodeLeft(t *testing.T) {
 	nodeName := "node1"
 	s1 := alive{
 		Node:        nodeName,
-		Addr:        []byte{127, 0, 0, 1},
+		Host:        "127.0.0.1",
 		Port:        8000,
 		Incarnation: 1,
 		Vsn:         m.config.BuildVsnArray(),
@@ -1797,7 +1769,7 @@ func TestMemberList_DeadNodeLeft(t *testing.T) {
 	// New alive node
 	s2 := alive{
 		Node:        nodeName,
-		Addr:        []byte{127, 0, 0, 2},
+		Host:        "127.0.0.2",
 		Port:        9000,
 		Incarnation: 3,
 		Meta:        []byte("foo"),
@@ -1815,7 +1787,7 @@ func TestMemberList_DeadNodeLeft(t *testing.T) {
 	if !bytes.Equal(state.Meta, []byte("foo")) {
 		t.Fatalf("meta should be updated")
 	}
-	if !bytes.Equal(state.Addr, []byte{127, 0, 0, 2}) {
+	if state.Host != "127.0.0.2" {
 		t.Fatalf("address should be updated")
 	}
 	if state.Port != 9000 {
@@ -1831,7 +1803,7 @@ func TestMemberList_DeadNode(t *testing.T) {
 	})
 	defer m.Shutdown()
 
-	a := alive{Node: "test", Addr: []byte{127, 0, 0, 1}, Incarnation: 1, Vsn: m.config.BuildVsnArray()}
+	a := alive{Node: "test", Host: "127.0.0.1", Incarnation: 1, Vsn: m.config.BuildVsnArray()}
 	m.aliveNode(&a, nil, false)
 
 	// Read the join event
@@ -1877,7 +1849,7 @@ func TestMemberList_DeadNode_Double(t *testing.T) {
 	m := GetMemberlist(t, nil)
 	defer m.Shutdown()
 
-	a := alive{Node: "test", Addr: []byte{127, 0, 0, 1}, Incarnation: 1, Vsn: m.config.BuildVsnArray()}
+	a := alive{Node: "test", Host: "127.0.0.1", Incarnation: 1, Vsn: m.config.BuildVsnArray()}
 	m.aliveNode(&a, nil, false)
 
 	state := m.nodeMap["test"]
@@ -1912,7 +1884,7 @@ func TestMemberList_DeadNode_OldDead(t *testing.T) {
 	m := GetMemberlist(t, nil)
 	defer m.Shutdown()
 
-	a := alive{Node: "test", Addr: []byte{127, 0, 0, 1}, Incarnation: 10, Vsn: m.config.BuildVsnArray()}
+	a := alive{Node: "test", Host: "127.0.0.1", Incarnation: 10, Vsn: m.config.BuildVsnArray()}
 	m.aliveNode(&a, nil, false)
 
 	state := m.nodeMap["test"]
@@ -1930,7 +1902,7 @@ func TestMemberList_DeadNode_AliveReplay(t *testing.T) {
 	m := GetMemberlist(t, nil)
 	defer m.Shutdown()
 
-	a := alive{Node: "test", Addr: []byte{127, 0, 0, 1}, Incarnation: 10, Vsn: m.config.BuildVsnArray()}
+	a := alive{Node: "test", Host: "127.0.0.1", Incarnation: 10, Vsn: m.config.BuildVsnArray()}
 	m.aliveNode(&a, nil, false)
 
 	d := dead{Node: "test", Incarnation: 10}
@@ -1950,7 +1922,7 @@ func TestMemberList_DeadNode_Refute(t *testing.T) {
 	m := GetMemberlist(t, nil)
 	defer m.Shutdown()
 
-	a := alive{Node: m.config.Name, Addr: []byte{127, 0, 0, 1}, Incarnation: 1, Vsn: m.config.BuildVsnArray()}
+	a := alive{Node: m.config.Name, Host: "127.0.0.1", Incarnation: 1, Vsn: m.config.BuildVsnArray()}
 	m.aliveNode(&a, nil, true)
 
 	// Clear queue
@@ -1989,11 +1961,11 @@ func TestMemberList_MergeState(t *testing.T) {
 	m := GetMemberlist(t, nil)
 	defer m.Shutdown()
 
-	a1 := alive{Node: "test1", Addr: []byte{127, 0, 0, 1}, Incarnation: 1, Vsn: m.config.BuildVsnArray()}
+	a1 := alive{Node: "test1", Host: "127.0.0.1", Incarnation: 1, Vsn: m.config.BuildVsnArray()}
 	m.aliveNode(&a1, nil, false)
-	a2 := alive{Node: "test2", Addr: []byte{127, 0, 0, 2}, Incarnation: 1, Vsn: m.config.BuildVsnArray()}
+	a2 := alive{Node: "test2", Host: "127.0.0.2", Incarnation: 1, Vsn: m.config.BuildVsnArray()}
 	m.aliveNode(&a2, nil, false)
-	a3 := alive{Node: "test3", Addr: []byte{127, 0, 0, 3}, Incarnation: 1, Vsn: m.config.BuildVsnArray()}
+	a3 := alive{Node: "test3", Host: "127.0.0.3", Incarnation: 1, Vsn: m.config.BuildVsnArray()}
 	m.aliveNode(&a3, nil, false)
 
 	s := suspect{Node: "test1", Incarnation: 1}
@@ -2002,25 +1974,25 @@ func TestMemberList_MergeState(t *testing.T) {
 	remote := []pushNodeState{
 		pushNodeState{
 			Name:        "test1",
-			Addr:        []byte{127, 0, 0, 1},
+			Host:        "127.0.0.1",
 			Incarnation: 2,
 			State:       StateAlive,
 		},
 		pushNodeState{
 			Name:        "test2",
-			Addr:        []byte{127, 0, 0, 2},
+			Host:        "127.0.0.2",
 			Incarnation: 1,
 			State:       StateSuspect,
 		},
 		pushNodeState{
 			Name:        "test3",
-			Addr:        []byte{127, 0, 0, 3},
+			Host:        "127.0.0.3",
 			Incarnation: 1,
 			State:       StateDead,
 		},
 		pushNodeState{
 			Name:        "test4",
-			Addr:        []byte{127, 0, 0, 4},
+			Host:        "127.0.0.4",
 			Incarnation: 2,
 			State:       StateAlive,
 		},
@@ -2077,9 +2049,6 @@ func TestMemberlist_Gossip(t *testing.T) {
 	addr1 := getBindAddr()
 	addr2 := getBindAddr()
 	addr3 := getBindAddr()
-	ip1 := []byte(addr1)
-	ip2 := []byte(addr2)
-	ip3 := []byte(addr3)
 
 	m1 := HostMemberlist(addr1.String(), t, func(c *Config) {
 		// Set the gossip interval fast enough to get a reasonable test,
@@ -2103,11 +2072,11 @@ func TestMemberlist_Gossip(t *testing.T) {
 	})
 	defer m3.Shutdown()
 
-	a1 := alive{Node: addr1.String(), Addr: ip1, Port: uint16(bindPort), Incarnation: 1, Vsn: m1.config.BuildVsnArray()}
+	a1 := alive{Node: addr1.String(), Host: addr1.String(), Port: uint16(bindPort), Incarnation: 1, Vsn: m1.config.BuildVsnArray()}
 	m1.aliveNode(&a1, nil, true)
-	a2 := alive{Node: addr2.String(), Addr: ip2, Port: uint16(bindPort), Incarnation: 1, Vsn: m2.config.BuildVsnArray()}
+	a2 := alive{Node: addr2.String(), Host: addr2.String(), Port: uint16(bindPort), Incarnation: 1, Vsn: m2.config.BuildVsnArray()}
 	m1.aliveNode(&a2, nil, false)
-	a3 := alive{Node: addr3.String(), Addr: ip3, Port: uint16(bindPort), Incarnation: 1, Vsn: m3.config.BuildVsnArray()}
+	a3 := alive{Node: addr3.String(), Host: addr3.String(), Port: uint16(bindPort), Incarnation: 1, Vsn: m3.config.BuildVsnArray()}
 	m1.aliveNode(&a3, nil, false)
 
 	// Gossip should send all this to m2. Retry a few times because it's UDP and
@@ -2152,8 +2121,6 @@ func TestMemberlist_GossipToDead(t *testing.T) {
 
 	addr1 := getBindAddr()
 	addr2 := getBindAddr()
-	ip1 := []byte(addr1)
-	ip2 := []byte(addr2)
 
 	m1 := HostMemberlist(addr1.String(), t, func(c *Config) {
 		c.GossipInterval = time.Millisecond
@@ -2170,9 +2137,9 @@ func TestMemberlist_GossipToDead(t *testing.T) {
 
 	defer m2.Shutdown()
 
-	a1 := alive{Node: addr1.String(), Addr: ip1, Port: uint16(bindPort), Incarnation: 1, Vsn: m1.config.BuildVsnArray()}
+	a1 := alive{Node: addr1.String(), Host: addr1.String(), Port: uint16(bindPort), Incarnation: 1, Vsn: m1.config.BuildVsnArray()}
 	m1.aliveNode(&a1, nil, true)
-	a2 := alive{Node: addr2.String(), Addr: ip2, Port: uint16(bindPort), Incarnation: 1, Vsn: m2.config.BuildVsnArray()}
+	a2 := alive{Node: addr2.String(), Host: addr2.String(), Port: uint16(bindPort), Incarnation: 1, Vsn: m2.config.BuildVsnArray()}
 	m1.aliveNode(&a2, nil, false)
 
 	// Shouldn't send anything to m2 here, node has been dead for 2x the GossipToTheDeadTime
@@ -2236,8 +2203,6 @@ func TestMemberlist_FailedRemote(t *testing.T) {
 func TestMemberlist_PushPull(t *testing.T) {
 	addr1 := getBindAddr()
 	addr2 := getBindAddr()
-	ip1 := []byte(addr1)
-	ip2 := []byte(addr2)
 
 	sink := registerInMemorySink(t)
 
@@ -2258,9 +2223,9 @@ func TestMemberlist_PushPull(t *testing.T) {
 	})
 	defer m2.Shutdown()
 
-	a1 := alive{Node: addr1.String(), Addr: ip1, Port: uint16(bindPort), Incarnation: 1, Vsn: m1.config.BuildVsnArray()}
+	a1 := alive{Node: addr1.String(), Host: addr1.String(), Port: uint16(bindPort), Incarnation: 1, Vsn: m1.config.BuildVsnArray()}
 	m1.aliveNode(&a1, nil, true)
-	a2 := alive{Node: addr2.String(), Addr: ip2, Port: uint16(bindPort), Incarnation: 1, Vsn: m2.config.BuildVsnArray()}
+	a2 := alive{Node: addr2.String(), Host: addr2.String(), Port: uint16(bindPort), Incarnation: 1, Vsn: m2.config.BuildVsnArray()}
 	m1.aliveNode(&a2, nil, false)
 
 	// Gossip should send all this to m2. It's UDP though so retry a few times

--- a/transport.go
+++ b/transport.go
@@ -26,10 +26,10 @@ type Packet struct {
 // interface is assumed to be best-effort and the stream interface is assumed to
 // be reliable.
 type Transport interface {
-	// FinalAdvertiseAddr is given the user's configured values (which
-	// might be empty) and returns the desired IP and port to advertise to
+	// FinalAdvertiseHost is given the user's configured values (which
+	// might be empty) and returns the desired Host and port to advertise to
 	// the rest of the cluster.
-	FinalAdvertiseAddr(ip string, port int) (net.IP, int, error)
+	FinalAdvertiseHost(host string, port int) (string, int, error)
 
 	// WriteTo is a packet-oriented interface that fires off the given
 	// payload to the given address in a connectionless fashion. This should


### PR DESCRIPTION
In k8s, the pod may be rebuild and its IP address is changed but domain name is unchanged. So we should use pod's domain name as member instead of IP address of pod to keep the stability of raft members.